### PR TITLE
Updated Layers to be Post Redistricting and add layers for Pre-Redistricting 

### DIFF
--- a/.github/workflows/beta-to-gh-pages.yml
+++ b/.github/workflows/beta-to-gh-pages.yml
@@ -1,8 +1,8 @@
-name: Deploy to GitHub Pages
+name: Beta branch to GitHub Pages
 on:
   push:
     branches:
-      - master
+      - svelte-mapbox-rewrite
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -16,8 +16,9 @@ jobs:
         env:
           API_KEY: 2J6__p_IWwUmOHYMKuMYjw
       - name: Deploy
-        uses: JamesIves/github-pages-deploy-action@4.1.3
+        uses: JamesIves/github-pages-deploy-action@4.4
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           BRANCH: gh-pages
-          FOLDER: .
+          FOLDER: build
+          TARGET_FOLDER: beta

--- a/.github/workflows/main-to-gh-pages.yml
+++ b/.github/workflows/main-to-gh-pages.yml
@@ -1,0 +1,23 @@
+name: Main/master branch deploy to GitHub Pages
+on:
+  push:
+    branches:
+      - master
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Build
+        run: |
+          npm install
+          npm run build
+        env:
+          API_KEY: 2J6__p_IWwUmOHYMKuMYjw
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.4
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages
+          FOLDER: .

--- a/src/js/index.js
+++ b/src/js/index.js
@@ -79,6 +79,18 @@ const layers = {
         `https://www.govtrack.us/congress/members/NY/${name}`
       )
   },
+  nycongress: {
+    name: 'Congressional Districts (Pre-Redistricting)',
+    sql: `SELECT * FROM all_bounds WHERE id = 'nycongress(old)'`,
+    textColor: '#ed1280',
+    lineColor: '#ed1280',
+    icon: 'static/NYCCo_domestic_a_01.jpg',
+    formatContent: (name, alt) =>
+      format_default(
+        name,
+        `https://www.govtrack.us/congress/members/NY/${name}`
+      )
+  },
   sa: {
     name: 'State Assembly Districts',
     sql: `SELECT * FROM all_bounds WHERE id = 'sa'`,
@@ -87,11 +99,28 @@ const layers = {
     icon: 'static/NYCCo_governement_law_01.jpg',
     formatContent: (name, alt) => format_default(name)
   },
+  sa: {
+    name: 'State Assembly Districts (Pre-Redist)',
+    sql: `SELECT * FROM all_bounds WHERE id = 'sa(old)'`,
+    textColor: '#d712ed',
+    lineColor: '#d712ed',
+    icon: 'static/NYCCo_governement_law_01.jpg',
+    formatContent: (name, alt) => format_default(name)
+  },
   ss: {
     name: 'State Senate Districts',
     sql: `SELECT * FROM all_bounds WHERE id = 'ss'`,
     textColor: '#9912ed',
     lineColor: '#9912ed',
+    icon: 'static/NYCCo_government_justice_01.jpg',
+    formatContent: (name, alt) =>
+      format_default(name, `https://www.nysenate.gov/district/${name}`)
+  },
+  ss: {
+    name: 'State Senate Districts (Pre-Redist)',
+    sql: `SELECT * FROM all_bounds WHERE id = 'ss(old)'`,
+    textColor: '#2c12ed',
+    lineColor: '#2c12ed',
     icon: 'static/NYCCo_government_justice_01.jpg',
     formatContent: (name, alt) =>
       format_default(name, `https://www.nysenate.gov/district/${name}`)


### PR DESCRIPTION
Updated and added archived layers from [DCP's Bytes of the Big Apple](https://www1.nyc.gov/site/planning/data-maps/open-data.page#district_political)

Colors need to be fixed as they aren't different from the post layers

- Congressional Districts (Pre-Redistricting)  `#ed1280`  compared to the post layer `#ed1212`
- State Assembly Districts (Pre-Redist) `#d712ed` compared to `#ed1294`
- State Senate Districts (Pre-Redist) `#2c12ed` compared to `#9912ed`