### PR TITLE
Fixes SentateURL by creating a redirect page and function

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -25,7 +25,7 @@
       // @ts-ignore
       const url = await layers[boundaryId].redirectUrl(district)
       redirect_url = url
-      //window.location.href = url
+      window.location.href = url
     }
   })
 

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -8,8 +8,26 @@
   import Map from './components/Map.svelte';
   import Sidebar from './components/Sidebar/Sidebar.svelte';
   import Controls from './components/Controls.svelte';
+  import { onMount } from 'svelte';
+  import { layers } from './assets/boundaries/index'
 
   const params = new URLSearchParams(window.location.search);
+
+  let redirected = false
+  let redirect_url = ''
+
+  onMount(async()=> {
+    //redirect if needed
+    if(params.get('redirect')){
+      redirected = true
+      const boundaryId = params.get('map') ?? 'ss'
+      const district = params.get('dist') ?? '0'
+      // @ts-ignore
+      const url = await layers[boundaryId].redirectUrl(district)
+      redirect_url = url
+      //window.location.href = url
+    }
+  })
 
   $: {
     $selectedDistrict
@@ -36,6 +54,14 @@
   }
 </script>
 
+{#if redirected}
+<div class="grid h-screen place-items-center">
+  <h2 class="text-2xl">You are being redirected...</h2>
+  {#if redirect_url}
+    <p>If you are stuck, try the following: <a class="underline text-blue-600" href="{redirect_url}">{redirect_url}</a></p>
+  {/if}
+</div>
+{:else}
 <main
   id="main"
   class="flex flex-col md:flex-row h-full absolute bottom-0 left-0 right-0"
@@ -46,3 +72,4 @@
     <Map />
   </div>
 </main>
+{/if}

--- a/src/assets/boundaries/index.ts
+++ b/src/assets/boundaries/index.ts
@@ -46,6 +46,9 @@ export interface ILayer {
   /** Url to link to for more info */
   formatUrl?: (name: string) => string;
 
+  /** Used with the redirect url param, to run a function to find and go to a url  */
+  redirectUrl?: Function;
+
   /** Formatted display name of district, e.g. transforms 101 to Manhattan - 1 */
   formatContent: (name: any) => string;
 }
@@ -169,7 +172,14 @@ export const layers: ILayers = {
     description_url: 'https://www.nysenate.gov/',
     sql: `SELECT * FROM all_bounds WHERE id = 'ss'`,
     icon: '⚖️',
-    formatUrl: name => `https://www.nysenate.gov/district/${name}`,
+    formatUrl: name => `/?redirect=true&map=ss&dist=${name}`,
+    redirectUrl: async (district: string) => {
+      // docs for api here: https://github.com/nysenate/GeoApi/blob/c92a0ef81ddf1f21b23751e26e1cb2a7021a3ec7/docs/index.rst
+      const requestURL = `https://4dvj5dcxge.execute-api.us-east-1.amazonaws.com/staging/https://pubgeo.nysenate.gov/api/v2/map/senate?showMembers=true&district=${district}`
+      const data = await fetch(requestURL).then(r => r.json())
+      const memberUrl = data.member.url
+      return memberUrl
+    },
     formatContent: name => format_default(name)
   },
   nta: {


### PR DESCRIPTION
Fixes #89 by creating an extra property `redirectUrl` for layers that does a lookup for the NYSenate url via the https://pubgeo.nysenate.gov/api/v2/map/senate endpoint.

See docs for the endpoint [here](https://github.com/nysenate/GeoApi/blob/c92a0ef81ddf1f21b23751e26e1cb2a7021a3ec7/docs/index.rst)

The `redirectUrl` is activated when /?redirect query parameter exist in the url.

![A screenshot of the redirect page. First line reads "You are being redirected..." Second line is an error message "If you are stuck, try the following: url to webpage"](https://github.com/BetaNYC/nyc-boundaries/assets/9166469/80f81839-82da-4004-ad15-fa8e29c9b880)
 