### PR TITLE
Updating the datasets and the boundaries to remove the old city council district lines

### DIFF
--- a/script/datasets.json
+++ b/script/datasets.json
@@ -43,15 +43,8 @@
   },
   {
     "id": "cc_upcoming",
-    "datasetName": "City Council Districts - Upcoming 2024",
-    "url": "https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycc_22c1.zip",
-    "nameCol": "CounDist",
-    "nameAlt": null
-  },
-  {
-    "id": "cc",
     "datasetName": "City Council Districts",
-    "url": "https://www.nyc.gov/assets/planning/download/zip/data-maps/open-data/nycc_21a.zip",
+    "url": "https://s-media.nyc.gov/agencies/dcp/assets/files/zip/data-tools/bytes/nycc_22c1.zip",
     "nameCol": "CounDist",
     "nameAlt": null
   },

--- a/src/assets/boundaries/index.ts
+++ b/src/assets/boundaries/index.ts
@@ -116,19 +116,9 @@ export const layers: ILayers = {
     icon: '🩺',
     formatContent: name => format_default(name)
   },
-  cc: {
-    name: 'City Council Districts (Prior to 2024)',
-    name_plural: 'City Council Districts (Prior to 2024)',
-    description: 'The New York City Council lines prior to 2024.',
-    description_url: 'https://council.nyc.gov/',
-    sql: `SELECT * FROM all_bounds WHERE id = 'cc'`,
-    icon: '🗽',
-    formatUrl: name => `https://council.nyc.gov/district-${name}`,
-    formatContent: name => format_default(name)
-  },
   cc_upcoming: {
-    name: 'City Council Districts (Current)',
-    name_plural: 'City Council Districts (Current)',
+    name: 'City Council Districts',
+    name_plural: 'City Council Districts',
     description:
       'The New York City Council is the lawmaking body of New York City. It has 51 members from 51 council districts throughout the five boroughs. The district lines have been updated in 2024.',
     description_url: 'https://council.nyc.gov/',


### PR DESCRIPTION
Updating the datasets and the boundaries to remove the old city council district lines.

I chose to avoid going through and updating the datasets because some of the files no longer resolve, so I instead just renamed the boundary and removed the old one. This is still "cc_upcoming" in the URL.